### PR TITLE
Fix audio does not play on mobile - kiwi.js

### DIFF
--- a/kiwi.js
+++ b/kiwi.js
@@ -1583,7 +1583,6 @@ app.event("message", async ({ body, event, context, client, message, say }) => {
   //end of xóa
 });
 
-////////////////////////////
 
 ///////////////////////////GỬI IPA AUDIO////////////////////////////////
 
@@ -1691,7 +1690,7 @@ app.event("message", async ({ body, event, context, client, message, say }) => {
       const result = await client.files.upload({
         channels: channel, //----> channels có s khi up load file
         thread_ts: destination,
-        filename: words,
+        filename: `${words}.mp3`,
         file: fs.createReadStream(file),
       });
       //   console.log(result);


### PR DESCRIPTION
Slack updates the code on iPhone and it seems that the audio files no work play if the extension of the file such as mp3 is not explicitly set.